### PR TITLE
Fixes needed by SCons project to run with python 2.7

### DIFF
--- a/src/epydoc/docintrospecter.py
+++ b/src/epydoc/docintrospecter.py
@@ -404,6 +404,8 @@ def introspect_class(cls, class_doc, module_name=None):
             for base in bases:
                 basedoc = introspect_docs(base)
                 class_doc.bases.append(basedoc)
+                if not hasattr(basedoc,'subclasses'):
+                    basedoc.subclasses=[]
                 basedoc.subclasses.append(class_doc)
 
             bases.reverse()

--- a/src/epydoc/docstringparser.py
+++ b/src/epydoc/docstringparser.py
@@ -537,7 +537,7 @@ def report_errors(api_doc, docindex, parse_errors, field_warnings):
             message = error.descr()
             messages.setdefault(message, []).append(error.linenum())
         message_items = list(messages.items())
-        message_items.sort(key=lambda a,b:six.cmp(min(a[1]), min(b[1])))
+        message_items.sort(lambda a,b:six.cmp(min(a[1]), min(b[1])))
         for message, linenums in message_items:
             linenums = [n for n in linenums if n is not None]
             if len(linenums) == 0:


### PR DESCRIPTION
When running on SCons, 

                 basedoc.subclasses.append(class_doc)
Was throwing an error as subclasses didn't exist.

Also the lambda in py2.7 would've been applied to the cmp arg and not the key. So fixed that too.
        message_items.sort(cmp=lambda a,b:six.cmp(min(a[1]), min(b[1])))

